### PR TITLE
Install npm devDependencies and prune them after.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -32,5 +32,9 @@ echo "-----> gem install bundler"
 gem install bundler
 echo "-----> bundle install"
 bundle install -j4 --deployment
+echo "-----> npm install --only=dev"
+npm install --only=dev
 echo "-----> bundle exec rake webpack:compile"
 bundle exec rake webpack:compile --trace
+echo "-----> npm prune"
+npm prune


### PR DESCRIPTION
In setting up a project with webpack-rails, I realized I'd have to move most of my `devDependencies` to `dependencies` to use this buildpack (or I'd have to tweak `NPM_CONFIG_PRODUCTION` or `NODE_ENV` in heroku). Because it seems like a bit of a hack (and results in bloat), I figured it'd be worth trying something like this.

`npm prune`, the star of this show, can remove unneeded node modules in a context-dependent way. When it detects `NODE_ENV=production`, it will prune modules specified in `devDependencies`. When there is no `NODE_ENV=production`, it will only prune extraneous[0] modules.

To fully implement this change, it will be ideal to change the [`package.json` for webpack-rails](https://github.com/mipearson/webpack-rails/blob/master/example/package.json) like this
```diff
-  "dependencies": {
+  "devDependencies": {
```

0: "Extraneous packages are packages that are not listed on the parent package's dependencies list." [source](https://docs.npmjs.com/cli/prune)