### PR TITLE
Exit on any error

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,6 +6,8 @@
 # This compiles assets to `public/webpack` when using default
 # configuration.
 
+set -o errexit # exit on error
+
 build_dir=$1
 cache_dir=$2
 env_dir=$3


### PR DESCRIPTION
Errors on `rake webpack:compile` should abort the deployment. This
change ensures that.

Fixes #9