### PR TITLE
Prevents the gem install bundler to install ri and rdoc

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -31,7 +31,7 @@ export_env_dir() {
 export_env_dir
 
 echo "-----> gem install bundler"
-gem install bundler
+gem install bundler --no-document
 echo "-----> bundle install"
 bundle install -j4 --deployment
 echo "-----> npm install --only=dev"


### PR DESCRIPTION
Since this buildpack depends on bundler to be installed, there are no need to install ri and rdoc with it.