### PR TITLE
Fix if condition on the yarn environment variable

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -60,7 +60,7 @@ fi
 echo "-----> bundle exec rake webpack:compile"
 bundle exec rake webpack:compile --trace
 
-if !$YARN; then
+if ! $YARN; then
   echo "-----> npm prune"
   npm prune
 fi


### PR DESCRIPTION
The previous version was causing the following error:

bin/compile: line 63: !false: command not found