### PR TITLE
Force install bundler to workaround RubyGems issue

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -44,7 +44,7 @@ export_env_dir() {
 export_env_dir
 
 echo "-----> gem install bundler"
-gem install bundler --no-document
+gem install bundler --no-document -v 1.17.3
 
 echo "-----> bundle install"
 bundle install -j4 --deployment

--- a/bin/compile
+++ b/bin/compile
@@ -44,7 +44,7 @@ export_env_dir() {
 export_env_dir
 
 echo "-----> gem install bundler"
-gem install bundler --no-document -v '~> 1.17'
+gem install bundler --no-document -v '~> 1.17' --force
 
 echo "-----> bundle install"
 bundle install -j4 --deployment


### PR DESCRIPTION
Fixes #22 

This fix simply adds the `--force` argument to the `gem install bundler` command, which is the workaround described in https://github.com/rubygems/rubygems/issues/2058

In the case where this issue is not being encountered (on old versions of Ruby/RubyGems), this change has no real bearing on the buildpack compile process. For versions that _are_ affected by the conflict issue described in #22, adding `--force` will allow it to install bundler and proceed with the rest of the build.